### PR TITLE
Extend name matching for position-recording to parent classes and interfaces

### DIFF
--- a/test-adapter/_testadapter/Macro.hx
+++ b/test-adapter/_testadapter/Macro.hx
@@ -107,7 +107,7 @@ class Macro {
 			}
 		}
 		loop(cls);
-		var regex = ~/(Test|Tests|TestCase|TestCases)/;
+		var regex = ~/Test/;
 		if (!hierarchyNames.exists(name -> regex.match(name))) {
 			return fields;
 		}

--- a/test-adapter/_testadapter/Macro.hx
+++ b/test-adapter/_testadapter/Macro.hx
@@ -101,14 +101,14 @@ class Macro {
 		var hierarchyNames = [];
 		function loop(c:ClassType) {
 			hierarchyNames.push(c.name);
-			c.interfaces.iter(r -> loop(r.t.get()));
+			c.interfaces.iter(function(r) loop(r.t.get()));
 			if (c.superClass != null) {
 				loop(c.superClass.t.get());
 			}
 		}
 		loop(cls);
 		var regex = ~/Test/;
-		if (!hierarchyNames.exists(name -> regex.match(name))) {
+		if (!hierarchyNames.exists(regex.match.bind())) {
 			return fields;
 		}
 		var className = makeLocation(cls.name);

--- a/test-adapter/_testadapter/Macro.hx
+++ b/test-adapter/_testadapter/Macro.hx
@@ -12,6 +12,7 @@ import _testadapter.data.TestPositions;
 import _testadapter.data.TestFilter;
 
 using StringTools;
+using Lambda;
 
 class Macro {
 	#if macro
@@ -97,7 +98,17 @@ class Macro {
 				return fields;
 			}
 		}
-		if (!~/(Test|Tests|TestCase|TestCases)/.match(cls.name)) {
+		var hierarchyNames = [];
+		function loop(c:ClassType) {
+			hierarchyNames.push(c.name);
+			c.interfaces.iter(r -> loop(r.t.get()));
+			if (c.superClass != null) {
+				loop(c.superClass.t.get());
+			}
+		}
+		loop(cls);
+		var regex = ~/(Test|Tests|TestCase|TestCases)/;
+		if (!hierarchyNames.exists(name -> regex.match(name))) {
 			return fields;
 		}
 		var className = makeLocation(cls.name);

--- a/test-adapter/_testadapter/Macro.hx
+++ b/test-adapter/_testadapter/Macro.hx
@@ -108,7 +108,7 @@ class Macro {
 		}
 		loop(cls);
 		var regex = ~/Test/;
-		if (!hierarchyNames.exists(regex.match.bind())) {
+		if (!hierarchyNames.exists(regex.match)) {
 			return fields;
 		}
 		var className = makeLocation(cls.name);


### PR DESCRIPTION
This way, any class that extends or implements something named "Test" is picked up as well.